### PR TITLE
Add monthly workflow to update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: cargo
-    directory: "/"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,38 @@
+name: Update deps
+
+on:
+  schedule:
+    - cron: 0 0 1 * *
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo update
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          branch: cargo-update
+          title: "cargo update"
+          commit-message: "cargo: update"
+          body: "Update dependencies to latest."


### PR DESCRIPTION
Disable Dependabot; it's too noisy.  Instead, run `cargo update` once a month and submit a PR.

This won't notice `nix` minor version bumps, unfortunately, and neither does deps.rs (I guess because it's an arch-specific dependency?).  And we probably don't want to declare compatibility with `nix` `>= 0.22, < 1`, since we can't promise that.  I don't have a suggestion here, but I'm okay with leaving that problem unresolved for now.

Sample PR in https://github.com/bgilbert/gptman/pull/4.