### PR TITLE
cargo: Widen nix dependency range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "crc",
  "lazy_static",
  "linefeed",
- "nix 0.22.3",
+ "nix 0.24.1",
  "pad",
  "rand 0.8.5",
  "serde",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -345,12 +345,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ count-zeroes = { version = "0.2.0", optional = true }
 cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "clap", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = "0.22"
+nix = ">= 0.22, < 0.25"


### PR DESCRIPTION
We're compatible with 0.24.

Moving to separate PR, since this isn't really related to #89.