### PR TITLE
workflows: Fix permissions of `cargo update` workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,6 +8,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+  pull-request: write
+
 jobs:
   update:
     name: Update


### PR DESCRIPTION
In newly-created GitHub organizations, `GITHUB_TOKEN` defaults to read-only permissions even for jobs that aren't running from a fork :tada:.  Explicitly specify the access we need.