### PR TITLE
workflows: Temporarily allow running release workflow manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-linux:


### PR DESCRIPTION
We need this to fix up the broken 1.0.0 release workflow.