### PR TITLE
cli: fix clippy 1.63.0 lints

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -985,8 +985,12 @@ where
     display_progress!(zeroes, count);
     let _ = writeln!(stdout_lock);
 
-    let mut sink = Vec::new();
-    let _ = terminal_lock.read(&mut sink);
+    #[allow(clippy::read_zero_byte_vec)]
+    {
+        let mut sink = Vec::new();
+        // resizes sink
+        let _ = terminal_lock.read(&mut sink);
+    }
     terminal_lock.restore(prev_terminal_state)?;
 
     res

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -3,7 +3,7 @@ use std::error::Error as ErrorTrait;
 use std::fmt;
 use std::io;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Error(String);
 
 impl Error {


### PR DESCRIPTION
@cecton, there's one other lint, and I'm not 100% sure whether the behavior is intentional.  Could you take a look?