### PR TITLE
cli: update to clap 4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,14 +22,16 @@ jobs:
         rust:
           - stable
           - 1.46.0 # lib MSRV
-          - 1.57.0 # cli MSRV
+          - 1.60.0 # cli MSRV
         include:
           - os: ubuntu-latest
             rust: stable
             lint: 1
           - rust: stable
             rust-args: --all-features
-          - rust: 1.57.0
+          - rust: 1.46.0
+            no-lock: 1
+          - rust: 1.60.0
             rust-args: --all-features
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,6 +45,15 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@v1
+
+      # If we're testing with Rust < 1.60, cargo won't be able to find
+      # the clap version specified in Cargo.lock, so remove the lockfile.
+      # This is safe because applications that only use us as a library will
+      # also ignore our Cargo.lock.
+      # https://users.rust-lang.org/t/optional-dependencies-and-msrv/82151
+      - name: Prune Cargo.lock
+        if: matrix.no-lock
+        run: rm Cargo.lock
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,26 +92,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -122,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -198,6 +197,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,12 +265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,14 +280,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
+name = "io-lifetimes"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "lazy_static"
@@ -297,6 +307,12 @@ dependencies = [
  "mortal",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "memchr"
@@ -602,6 +618,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +699,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +720,6 @@ dependencies = [
  "phf",
  "phf_codegen",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -791,3 +825,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,11 @@ pad = { version = "0.1", optional = true }
 unicode-width = { version = "0.1.8", optional = true }
 linefeed = { version = "0.6.0", optional = true }
 rand = { version = "0.8", optional = true }
-clap = { version = "3.1", optional = true, features = ["derive"] }
+# We don't actually support clap 3.  But cargo < 1.60 ignores clap versions
+# >= 4, and our MSRV is lower than that when the CLI is disabled.  Ensure
+# older cargo can find _some_ clap version so it won't fail.
+# https://users.rust-lang.org/t/optional-dependencies-and-msrv/82151
+clap = { version = ">= 3, < 5", optional = true, features = ["derive", "wrap_help"] }
 count-zeroes = { version = "0.2.0", optional = true }
 
 [features]

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -1,7 +1,7 @@
-use clap::{ArgEnum, Parser};
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
-#[derive(ArgEnum, Clone, Debug)]
+#[derive(Clone, Debug, ValueEnum)]
 pub enum Column {
     Device,
     Start,
@@ -15,36 +15,36 @@ pub enum Column {
 }
 
 #[derive(Parser, Debug)]
-#[clap(version)]
+#[command(next_display_order = None, version)]
 pub struct Opt {
     /// display partitions and exit
-    #[clap(short = 'l', long = "list")]
+    #[arg(short = 'l', long = "list")]
     pub print: bool,
 
     /// output columns
-    #[clap(
+    #[arg(
         short = 'o',
         long = "output",
-        arg_enum,
+        value_enum,
         default_value = "device,start,end,sectors,size,type,guid,attributes,name",
-        use_value_delimiter = true
+        value_delimiter = ','
     )]
     pub columns: Vec<Column>,
 
     /// device to open
-    #[clap(name = "DEVICE", parse(from_os_str))]
+    #[arg(value_name = "DEVICE")]
     pub device: PathBuf,
 
     /// initialize a new GPT on the disk
-    #[clap(short = 'i', long = "init")]
+    #[arg(short = 'i', long = "init")]
     pub init: bool,
 
     /// sector size
-    #[clap(short = 'b', long = "sector-size")]
+    #[arg(short = 'b', long = "sector-size")]
     pub sector_size: Option<u64>,
 
     /// partition alignment
-    #[clap(short = 'a', long = "align")]
+    #[arg(short = 'a', long = "align")]
     pub align: Option<u64>,
 }
 


### PR DESCRIPTION
Specify `next_display_order = None` to keep the option list sorted in `--help`.

Pretend to continue supporting clap 3 in Cargo.toml so cargo < 1.60 won't fail when building with the CLI disabled.  Delete `Cargo.lock` in MSRV CI jobs for the same reason.
