### PR TITLE
cargo: widen nix dependency range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ count-zeroes = { version = "0.2.0", optional = true }
 cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "clap", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = ">= 0.22, < 0.25"
+nix = ">= 0.22, < 0.27"


### PR DESCRIPTION
Based on the changelog for nix, it does not seem that there are relevant changes.

Happy to perform any additional testing that's needed here though!