### PR TITLE
Allow a wider version range for nix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ count-zeroes = { version = "0.2.0", optional = true }
 cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "clap", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = ">= 0.22, < 0.25"
+nix = ">= 0.22, < 0.27"


### PR DESCRIPTION
0.26 seems to work just fine.