### PR TITLE
feat: flag to create pmbr marked as bootable

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -529,7 +529,7 @@ fn write(gpt: &mut GPT, opt: &Opt) -> Result<()> {
     gpt.write_into(&mut f)?;
 
     if opt.init {
-        GPT::write_protective_mbr_into(&mut f, gpt.sector_size)?;
+        GPT::write_protective_mbr_into(&mut f, gpt.sector_size, false)?;
         println!("protective MBR has been written");
     }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -529,7 +529,7 @@ fn write(gpt: &mut GPT, opt: &Opt) -> Result<()> {
     gpt.write_into(&mut f)?;
 
     if opt.init {
-        GPT::write_protective_mbr_into(&mut f, gpt.sector_size, false)?;
+        GPT::write_protective_mbr_into(&mut f, gpt.sector_size)?;
         println!("protective MBR has been written");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1231,6 +1231,11 @@ impl GPT {
 
     /// This function writes a protective MBR in the first sector of the disk
     /// starting at byte 446 and ending at byte 511. Any existing data will be overwritten.
+    ///
+    /// * `bootable` - Indicates whether the partition in the MBR partition table should be marked
+    /// as bootable. Some legacy BIOS systems do not consider a disk to be bootable if there isn't
+    /// an MBR partition marked as bootable, so this should be set to `true` if you intend the disk
+    /// to be bootable on those systems.
     pub fn write_protective_mbr_into<W: ?Sized>(
         mut writer: &mut W,
         sector_size: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1231,15 +1231,23 @@ impl GPT {
 
     /// This function writes a protective MBR in the first sector of the disk
     /// starting at byte 446 and ending at byte 511. Any existing data will be overwritten.
-    pub fn write_protective_mbr_into<W: ?Sized>(mut writer: &mut W, sector_size: u64) -> Result<()>
+    pub fn write_protective_mbr_into<W: ?Sized>(
+        mut writer: &mut W,
+        sector_size: u64,
+        bootable: bool,
+    ) -> Result<()>
     where
         W: Write + Seek,
     {
         let size = writer.seek(SeekFrom::End(0))? / sector_size - 1;
         writer.seek(SeekFrom::Start(446))?;
         // partition 1
+        if bootable {
+            writer.write_all(&[0x80])?;
+        } else {
+            writer.write_all(&[0x00])?;
+        }
         writer.write_all(&[
-            0x00, // status
             0x00, 0x02, 0x00, // CHS address of first absolute sector
             0xee, // partition type
             0xff, 0xff, 0xff, // CHS address of last absolute sector
@@ -1812,7 +1820,7 @@ mod test {
         fn test(ss: u64) {
             let data = vec![2; ss as usize * 100];
             let mut cur = io::Cursor::new(data);
-            GPT::write_protective_mbr_into(&mut cur, ss).unwrap();
+            GPT::write_protective_mbr_into(&mut cur, ss, false).unwrap();
             let data = cur.get_ref();
 
             assert_eq!(data[510], 0x55);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1255,6 +1255,7 @@ impl GPT {
     {
         Self::write_protective_mbr_into_impl(&mut writer, sector_size, true)
     }
+
     fn write_protective_mbr_into_impl<W: ?Sized>(
         mut writer: &mut W,
         sector_size: u64,


### PR DESCRIPTION
We're using gptman to build a bootable disk image, that needs to boot on both BIOS and UEFI systems. We've found that some legacy BIOS systems don't consider a disk to be bootable unless the bootable flag is set on the [PMBR](https://www.rodsbooks.com/gdisk/bios.html).

This change is an API break, if you'd prefer to add a separate function or prevent an API break some other way, let me know!