### PR TITLE
fix: fix get sector size on mips64

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -54,6 +54,11 @@ pub fn reread_partition_table(file: &mut fs::File) -> Result<(), BlockError> {
 }
 
 /// Makes an ioctl call to obtain the sector size of a block device
+///
+/// Under normal conditions, `get_sector_size` retrieves the logical sector size using the `BLKSSZGET` ioctl command.
+/// If the system returns an error, the function handles it appropriately. However, in the rare event that the system
+/// reports success (0) but writes a negative value, the function will default to 512 bytes to ensure stability.
+/// This is a safeguard against unexpected system behavior.
 pub fn get_sector_size(file: &mut fs::File) -> Result<u64, BlockError> {
     let metadata = file.metadata().map_err(BlockError::Metadata)?;
     let mut sector_size = 512;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -5,9 +5,13 @@ use std::os::unix::io::AsRawFd;
 use thiserror::Error;
 
 mod ioctl {
-    use nix::{ioctl_none, ioctl_read_bad};
+    use nix::{ioctl_none, ioctl_read_bad, request_code_none};
 
-    ioctl_read_bad!(blksszget, 0x1268, u64);
+    ioctl_read_bad!(
+        blksszget,
+        request_code_none!(0x12, 104),
+        ::std::os::raw::c_int
+    );
     ioctl_none!(blkrrpart, 0x12, 95);
 }
 
@@ -50,7 +54,7 @@ pub fn reread_partition_table(file: &mut fs::File) -> Result<(), BlockError> {
 }
 
 /// Makes an ioctl call to obtain the sector size of a block device
-pub fn get_sector_size(file: &mut fs::File) -> Result<u64, BlockError> {
+pub fn get_sector_size(file: &mut fs::File) -> Result<i32, BlockError> {
     let metadata = file.metadata().map_err(BlockError::Metadata)?;
     let mut sector_size = 512;
 


### PR DESCRIPTION
This PR will fix the `get_sector_size` function returning `ENOTTY` on the MIPS64 architecture.